### PR TITLE
feat/fix: 补充平滑动画并修复 QQ 键盘遮挡输入框问题

### DIFF
--- a/src/io/github/liuran001/mmliquidglass/LiquidGlassInstaller.java
+++ b/src/io/github/liuran001/mmliquidglass/LiquidGlassInstaller.java
@@ -210,6 +210,17 @@ final class LiquidGlassInstaller {
                 "stale host from a previous Activity dropped, reinstalling");
     }
 
+    /**
+     * The pager the glass is currently refracting, or null before the first
+     * install. Re-read on every use rather than captured: {@link #resetState}
+     * drops it when an Activity is recreated and the next install publishes a
+     * fresh instance, so a cached reference would go stale for the rest of the
+     * process.
+     */
+    static ViewGroup currentPager() {
+        return sPagerRef.get();
+    }
+
     private static void install(ViewGroup tabView) {
         ViewGroup parent = tabView.getParent() instanceof ViewGroup
                 ? (ViewGroup) tabView.getParent() : null;
@@ -262,9 +273,11 @@ final class LiquidGlassInstaller {
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.WRAP_CONTENT,
                 android.view.Gravity.BOTTOM | android.view.Gravity.CENTER_HORIZONTAL);
-        // The navigation inset only counts once the window has been grown to
-        // cover it — before that the pill's parent already stops above the
-        // gesture bar, and adding it again floats the pill far too high.
+        // The navigation inset only counts once the window reaches under it —
+        // either because extendUnderNavBar grew it or because the app already
+        // draws edge to edge. Short of that the pill's parent stops above the
+        // gesture bar, and adding it again floats the pill far too high. Left
+        // out here and applied below, once that is known.
         // Anchored on the parent, not the bar: the bar is about to be detached,
         // and a detached view reports no insets at all. Reading from it later
         // would silently drop the correction and let the bar sink onto the
@@ -335,12 +348,16 @@ final class LiquidGlassInstaller {
             LiquidGlassModule.logErr("could not remove all stock tab chrome", t);
         }
 
-        boolean underNav = extendUnderNavBar(ctx);
-        if (underNav || LiquidGlassModule.app() == HostApp.QQ) {
+        // QQ is the one host where the inset counts without us growing the
+        // window: extendUnderNavBar bails out there on purpose (see it for
+        // why), but QQ already lays its own decor out edge to edge, so the
+        // pill's parent does reach under the gesture bar and the correction is
+        // owed all the same.
+        boolean insetCounts = extendUnderNavBar(ctx)
+                || LiquidGlassModule.app() == HostApp.QQ;
+        if (insetCounts) {
             hostLp.bottomMargin = bottomOffset - shadowPad + navigationInset;
             host.setLayoutParams(hostLp);
-        }
-        if (underNav || LiquidGlassModule.app() == HostApp.QQ) {
             // The first real insets dispatch can arrive either side of host
             // creation. Re-read the shared cache on the next UI turn so both
             // orders converge on the same bottom anchor.

--- a/src/io/github/liuran001/mmliquidglass/LiquidGlassInstaller.java
+++ b/src/io/github/liuran001/mmliquidglass/LiquidGlassInstaller.java
@@ -1799,6 +1799,9 @@ final class LiquidGlassInstaller {
         if (Build.VERSION.SDK_INT < 30) {
             return false;
         }
+        if (LiquidGlassModule.app() == HostApp.QQ) {
+            return false; // QQ NT breaks IME window insets if the root decor is hijacked
+        }
         try {
             Activity activity = activityOf(ctx);
             if (activity == null) {

--- a/src/io/github/liuran001/mmliquidglass/LiquidGlassInstaller.java
+++ b/src/io/github/liuran001/mmliquidglass/LiquidGlassInstaller.java
@@ -321,6 +321,8 @@ final class LiquidGlassInstaller {
         sBarHeight = barHeight;
         sLastIndex = -1;
 
+        TabBarBridge.tryHookPager(backdrop);
+
         // Cosmetic cleanup cannot invalidate the structural install. If an app
         // skin changes one of these details, keep the functional floating bar
         // and report the degraded effect rather than trying to tear it back out.

--- a/src/io/github/liuran001/mmliquidglass/LiquidGlassInstaller.java
+++ b/src/io/github/liuran001/mmliquidglass/LiquidGlassInstaller.java
@@ -336,11 +336,11 @@ final class LiquidGlassInstaller {
         }
 
         boolean underNav = extendUnderNavBar(ctx);
-        if (underNav) {
+        if (underNav || LiquidGlassModule.app() == HostApp.QQ) {
             hostLp.bottomMargin = bottomOffset - shadowPad + navigationInset;
             host.setLayoutParams(hostLp);
         }
-        if (underNav) {
+        if (underNav || LiquidGlassModule.app() == HostApp.QQ) {
             // The first real insets dispatch can arrive either side of host
             // creation. Re-read the shared cache on the next UI turn so both
             // orders converge on the same bottom anchor.

--- a/src/io/github/liuran001/mmliquidglass/LiquidGlassModule.java
+++ b/src/io/github/liuran001/mmliquidglass/LiquidGlassModule.java
@@ -47,6 +47,17 @@ public class LiquidGlassModule extends XposedModule {
                 });
     }
 
+    /** Hooks an executable, intercepting its call chain completely. */
+    static void hookIntercept(java.lang.reflect.Executable ex, InterceptCallback fn) {
+        LiquidGlassModule self = sSelf;
+        if (self == null) throw new IllegalStateException("module instance not attached yet");
+        self.hook(ex).intercept(fn::intercept);
+    }
+
+    interface InterceptCallback {
+        Object intercept(XposedInterface.Chain chain) throws Throwable;
+    }
+
     interface AfterCallback {
         void after(XposedInterface.Chain chain) throws Throwable;
     }

--- a/src/io/github/liuran001/mmliquidglass/LiquidGlassModule.java
+++ b/src/io/github/liuran001/mmliquidglass/LiquidGlassModule.java
@@ -47,11 +47,24 @@ public class LiquidGlassModule extends XposedModule {
                 });
     }
 
-    /** Hooks an executable, intercepting its call chain completely. */
+    /**
+     * Hooks an executable, handing the callback the whole call chain so it can
+     * rewrite arguments, substitute a result, or drop the call outright.
+     *
+     * <p>PROTECTIVE like {@link #hookAfter}: a throw out of the callback must
+     * never surface in the host's own frame. The chain here wraps app calls
+     * that legitimately throw — ViewPager2 rejects setCurrentItem mid
+     * fake-drag — and reflection would repackage that as an
+     * InvocationTargetException the app has no catch for.
+     */
     static void hookIntercept(java.lang.reflect.Executable ex, InterceptCallback fn) {
         LiquidGlassModule self = sSelf;
-        if (self == null) throw new IllegalStateException("module instance not attached yet");
-        self.hook(ex).intercept(fn::intercept);
+        if (self == null) {
+            throw new IllegalStateException("module instance not attached yet");
+        }
+        self.hook(ex)
+                .setExceptionMode(ExceptionMode.PROTECTIVE)
+                .intercept(fn::intercept);
     }
 
     interface InterceptCallback {

--- a/src/io/github/liuran001/mmliquidglass/TabBarBridge.java
+++ b/src/io/github/liuran001/mmliquidglass/TabBarBridge.java
@@ -452,4 +452,24 @@ final class TabBarBridge {
         }
         return -1;
     }
+
+    private static volatile boolean sHookedPager;
+
+    static void tryHookPager(ViewGroup pager) {
+        if (sHookedPager || pager == null) return;
+        try {
+            Class<?> viewPagerCls = pager.getClass();
+            Method setItem = viewPagerCls.getMethod("setCurrentItem", int.class);
+            Method setItemSmooth = viewPagerCls.getMethod("setCurrentItem", int.class, boolean.class);
+            LiquidGlassModule.hookIntercept(setItem, chain -> {
+                Object[] args = chain.getArgs().toArray();
+                setItemSmooth.invoke(chain.getThisObject(), (Integer) args[0], true);
+                return null;
+            });
+            sHookedPager = true;
+            LiquidGlassModule.log(android.util.Log.INFO, "Hooked ViewPager: " + viewPagerCls.getName());
+        } catch (Throwable t) {
+            LiquidGlassModule.log(android.util.Log.WARN, "No ViewPager to hook: " + t);
+        }
+    }
 }

--- a/src/io/github/liuran001/mmliquidglass/TabBarBridge.java
+++ b/src/io/github/liuran001/mmliquidglass/TabBarBridge.java
@@ -458,16 +458,35 @@ final class TabBarBridge {
     static void tryHookPager(ViewGroup pager) {
         if (sHookedPager || pager == null) return;
         try {
-            Class<?> viewPagerCls = pager.getClass();
-            Method setItem = viewPagerCls.getMethod("setCurrentItem", int.class);
-            Method setItemSmooth = viewPagerCls.getMethod("setCurrentItem", int.class, boolean.class);
-            LiquidGlassModule.hookIntercept(setItem, chain -> {
-                Object[] args = chain.getArgs().toArray();
-                setItemSmooth.invoke(chain.getThisObject(), (Integer) args[0], true);
-                return null;
-            });
-            sHookedPager = true;
-            LiquidGlassModule.log(android.util.Log.INFO, "Hooked ViewPager: " + viewPagerCls.getName());
+            Class<?> cls = pager.getClass();
+            Method setItemBool = null;
+            while (cls != null && cls != Object.class) {
+                try {
+                    setItemBool = cls.getDeclaredMethod("setCurrentItem", int.class, boolean.class);
+                    break;
+                } catch (NoSuchMethodException ignored) {}
+                cls = cls.getSuperclass();
+            }
+            if (setItemBool != null) {
+                final Method setItemSmooth = setItemBool;
+                LiquidGlassModule.hookIntercept(setItemSmooth, chain -> {
+                    Object[] args = chain.getArgs().toArray();
+                    boolean smooth = false;
+                    if (args.length >= 2 && args[1] instanceof Boolean) {
+                        smooth = (Boolean) args[1];
+                    }
+                    if (!smooth) {
+                        // redirect to smooth scroll (avoid infinite loop by checking if it was false)
+                        setItemSmooth.invoke(chain.getThisObject(), args[0], true);
+                        return null; // swallow the original hard-cut call
+                    }
+                    return chain.proceed(); // allow smooth calls through
+                });
+                sHookedPager = true;
+                LiquidGlassModule.log(android.util.Log.INFO, "Hooked ViewPager: " + setItemBool.getDeclaringClass().getName());
+            } else {
+                LiquidGlassModule.log(android.util.Log.WARN, "No setCurrentItem(int, boolean) found on " + pager.getClass());
+            }
         } catch (Throwable t) {
             LiquidGlassModule.log(android.util.Log.WARN, "No ViewPager to hook: " + t);
         }

--- a/src/io/github/liuran001/mmliquidglass/TabBarBridge.java
+++ b/src/io/github/liuran001/mmliquidglass/TabBarBridge.java
@@ -453,8 +453,21 @@ final class TabBarBridge {
         return -1;
     }
 
+    /** One hook per process; the instance it applies to is resolved per call. */
     private static volatile boolean sHookedPager;
 
+    /**
+     * Restores the page transition both hosts throw away on a tab tap.
+     *
+     * <p>Neither app animates the swap itself: the bar handler calls
+     * {@code setCurrentItem(index, false)} and the pages hard-cut. Rewriting
+     * that one flag to true hands the slide back to the pager, which is the
+     * motion the droplet was already animating alongside.
+     *
+     * <p>Hooked once and left in place: the method belongs to the app's class,
+     * not to the instance, so re-hooking on every install would stack
+     * redundant chains on the same executable.
+     */
     static void tryHookPager(ViewGroup pager) {
         if (sHookedPager || pager == null) return;
         try {
@@ -470,25 +483,45 @@ final class TabBarBridge {
             if (setItemBool != null) {
                 final Method setItemSmooth = setItemBool;
                 LiquidGlassModule.hookIntercept(setItemSmooth, chain -> {
+                    // Binding is per class, so every pager in the app lands
+                    // here. On QQ the declaring class is AndroidX's own
+                    // ViewPager2, shared with the profile card carousel and
+                    // every TabLayoutMediator in the app; on WeChat it is the
+                    // WxViewPager base of the home pager. Only the backdrop the
+                    // glass is refracting may be rewritten — everywhere else an
+                    // instant jump is what the app asked for, and turning it
+                    // into a scroll animates UI this module has no business
+                    // touching.
+                    if (chain.getThisObject() != LiquidGlassInstaller.currentPager()) {
+                        return chain.proceed();
+                    }
                     Object[] args = chain.getArgs().toArray();
                     boolean smooth = false;
                     if (args.length >= 2 && args[1] instanceof Boolean) {
                         smooth = (Boolean) args[1];
                     }
                     if (!smooth) {
-                        // redirect to smooth scroll (avoid infinite loop by checking if it was false)
+                        // Re-enters this same hook one level down, where smooth
+                        // is now true and the branch below proceeds: that is
+                        // what stops it recursing.
                         setItemSmooth.invoke(chain.getThisObject(), args[0], true);
                         return null; // swallow the original hard-cut call
                     }
                     return chain.proceed(); // allow smooth calls through
                 });
                 sHookedPager = true;
-                LiquidGlassModule.log(android.util.Log.INFO, "Hooked ViewPager: " + setItemBool.getDeclaringClass().getName());
+                LiquidGlassModule.log(android.util.Log.INFO,
+                        "hooked " + setItemBool.getDeclaringClass().getName()
+                                + ".setCurrentItem(int, boolean) for the backdrop's"
+                                + " page transition");
             } else {
-                LiquidGlassModule.log(android.util.Log.WARN, "No setCurrentItem(int, boolean) found on " + pager.getClass());
+                LiquidGlassModule.log(android.util.Log.WARN,
+                        "no setCurrentItem(int, boolean) on " + pager.getClass()
+                                + ", pages will hard-cut between tabs");
             }
         } catch (Throwable t) {
-            LiquidGlassModule.log(android.util.Log.WARN, "No ViewPager to hook: " + t);
+            LiquidGlassModule.log(android.util.Log.WARN,
+                    "could not hook the backdrop pager: " + t);
         }
     }
 }


### PR DESCRIPTION
## 改进内容 / Changes
本 PR 在原生框架的基础上，对微信和 QQ 端的交互体验与兼容性进行了两处关键修复：

1. **补充微信标签页平滑过渡动画**：
   - 增加 `LiquidGlassModule.hookIntercept` 工具方法，支持在 LibXposed 环境下拦截并丢弃原始调用。
   - 新增 `TabBarBridge.tryHookPager(ViewGroup pager)`，动态获取微信底部的 `ViewPager`。
   - 拦截微信默认调用的 `setCurrentItem(int, boolean)`（微信内部传参为 `false`），将其阻断并重定向为传参 `true` 的平滑滑动调用，恢复底栏切换时的系统过渡动画。
   - `LiquidGlassInstaller` 在构建 `sPagerRef` 时，将 `backdrop` 传入 `TabBarBridge` 进行懒加载 Hook。

2. **修复 QQ (NT 9.3.x) 键盘遮挡输入框问题**：
   - **问题原因**：`extendUnderNavBar` 方法会在根 `DecorView` 上设置 `SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION` 并强行拦截 `WindowInsets`。这在微信侧表现正常，但在最新的 QQ NT 架构（如 9.3.55）中，会破坏原生输入法键盘弹出的重绘调整（`adjustResize`），导致聊天界面的输入框被弹出的键盘遮挡。
   - **解决方案**：在 `extendUnderNavBar` 方法执行前加入 `HostApp.QQ` 判断，针对 QQ 跳过该全局 Window 伸展逻辑。QQ 默认的视图层级已处理好全屏状态，跳过该拉伸操作即可恢复正常的键盘 Insets 响应，同时保持底栏正常的导航栏高度补偿。

